### PR TITLE
Emergency fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 .vscode/
 .idea/
 .DS_Store
+tests/schemathesis_reports/junit.xml


### PR DESCRIPTION
Emergency fix
Running schemathesis tests:
- fixed the server path
- added report creation at ${PWD}/tests/schemathesis_reports
- the report file at ${PWD}/tests/schemathesis_reports/junit.xml describes the server responses and compares them with the expected response according to the api documentation
- before running tests using the make test-api command, the irrelevant junit.xml is deleted
- the list of endpoints is limited